### PR TITLE
Added missing subView layout for percentage label

### DIFF
--- a/M13ProgressView/Classes/Progress Views/M13ProgressViewRing.m
+++ b/M13ProgressView/Classes/Progress Views/M13ProgressViewRing.m
@@ -357,6 +357,7 @@
     _backgroundLayer.frame = self.bounds;
     _progressLayer.frame = self.bounds;
     _iconLayer.frame = self.bounds;
+    _percentageLabel.frame = self.bounds;
     
     //Update font size
     _percentageLabel.font = [UIFont systemFontOfSize:(self.bounds.size.width / 5)];


### PR DESCRIPTION
If an M13ProgressViewRing was initialised without a frame, the percentage value would never be shown as it's frame remained un-set  even after setFrame was called on the parent view. Updated to set percentage label frame to bounds as per other sibling views.
