### PR TITLE
Fill color of M13ProgressViewPie changes when primary color is set.

### DIFF
--- a/Classes/ProgressViews/M13ProgressViewPie.m
+++ b/Classes/ProgressViews/M13ProgressViewPie.m
@@ -124,6 +124,7 @@
 {
     [super setPrimaryColor:primaryColor];
     _progressLayer.strokeColor = self.primaryColor.CGColor;
+    _progressLayer.fillColor   = self.primaryColor.CGColor;
     _iconLayer.fillColor = self.primaryColor.CGColor;
     _indeterminateLayer.fillColor = self.primaryColor.CGColor;
     [self setNeedsDisplay];


### PR DESCRIPTION
Changed M13ProgressViewPie to update the fill color of the progress layer when calling setPrimaryColor:.
