### PR TITLE
Make finishProgress and cancelProgress always use the main queue

### DIFF
--- a/Classes/NavigationController/UINavigationController+M13ProgressViewBar.m
+++ b/Classes/NavigationController/UINavigationController+M13ProgressViewBar.m
@@ -89,22 +89,24 @@ static char indeterminateLayerKey;
 
 - (void)finishProgress
 {
-    if ([self getProgressView]) {
-        UIView *progressView = [self getProgressView];
-        
-        [UIView animateWithDuration:0.1 animations:^{
-            CGRect progressFrame = progressView.frame;
-            progressFrame.size.width = self.navigationBar.frame.size.width;
-            progressView.frame = progressFrame;
-        } completion:^(BOOL finished) {
-            [UIView animateWithDuration:0.5 animations:^{
-                progressView.alpha = 0;
+    UIView *progressView = [self getProgressView];
+
+    if (progressView) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [UIView animateWithDuration:0.1 animations:^{
+                CGRect progressFrame = progressView.frame;
+                progressFrame.size.width = self.navigationBar.frame.size.width;
+                progressView.frame = progressFrame;
             } completion:^(BOOL finished) {
-                [progressView removeFromSuperview];
-                progressView.alpha = 1;
-                [self setTitle:nil];
+                [UIView animateWithDuration:0.5 animations:^{
+                    progressView.alpha = 0;
+                } completion:^(BOOL finished) {
+                    [progressView removeFromSuperview];
+                    progressView.alpha = 1;
+                    [self setTitle:nil];
+                }];
             }];
-        }];
+        });
     }
 }
 
@@ -113,13 +115,15 @@ static char indeterminateLayerKey;
     UIView *progressView = [self getProgressView];
     
     if (progressView) {
-        [UIView animateWithDuration:0.5 animations:^{
-            progressView.alpha = 0;
-        } completion:^(BOOL finished) {
-            [progressView removeFromSuperview];
-            progressView.alpha = 1;
-            [self setTitle:nil];
-        }];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [UIView animateWithDuration:0.5 animations:^{
+                progressView.alpha = 0;
+            } completion:^(BOOL finished) {
+                [progressView removeFromSuperview];
+                progressView.alpha = 1;
+                [self setTitle:nil];
+            }];
+        });
     }
 }
 


### PR DESCRIPTION
- Fix incorrect progress initialization, max should be 1.0, not 100.
- Make finishProgress and cancelProgress always use the main queue.
