### PR TITLE
changed “drawRect” of M13ProgressViewBar

### DIFF
--- a/Classes/ProgressViews/M13ProgressViewBar.m
+++ b/Classes/ProgressViews/M13ProgressViewBar.m
@@ -615,6 +615,8 @@
             [path addLineToPoint:CGPointMake(_progressBarThickness / 2.0, _progressLayer.frame.size.height * self.progress)];
             [_progressLayer setPath:path.CGPath];
         }
+    } else {
+        [_progressLayer setPath:nil];
     }
 }
 


### PR DESCRIPTION
 if self.progress is 0, then we set the path of _progressLayer to nil. This will effectively “erase” progress. This is useful if M13ProgressViewBar is used in a reusable view, like a UITableViewCell.
