### PR TITLE
Fixed progress width calculation

### DIFF
--- a/Classes/NavigationController/UINavigationController+M13ProgressViewBar.m
+++ b/Classes/NavigationController/UINavigationController+M13ProgressViewBar.m
@@ -163,7 +163,13 @@ static char secondaryColorKey;
 	}
     
     //Calculate the frame of the navigation bar, based off the orientation.
-    CGSize screenSize = [UIScreen mainScreen].bounds.size;
+    UIView *topView = self.topViewController.view;
+    CGSize screenSize;
+    if (topView) {
+        screenSize = topView.bounds.size;
+    } else {
+        screenSize = [UIScreen mainScreen].bounds.size;
+    }
     CGFloat width = 0.0;
     CGFloat height = 0.0;
     //Calculate the width of the screen


### PR DESCRIPTION
Instead of using UIScreen, if possible use the topViewController's view property. This'll work much better if the view is within a UISplitViewController or if it's within a multitasking view on iOS 9.