### PR TITLE
Use Preprocessor Macro for App Extension target to avoid compile erro…

### DIFF
--- a/Classes/NavigationController/UINavigationController+M13ProgressViewBar.m
+++ b/Classes/NavigationController/UINavigationController+M13ProgressViewBar.m
@@ -129,6 +129,26 @@ static char secondaryColorKey;
     }
 }
 
+#pragma mark Orientation
+
+- (UIInterfaceOrientation)currentDeviceOrientation
+{
+    UIInterfaceOrientation orientation;
+
+    //Define "M13_APP_EXTENSIONS" Preprocessor Macro for App Extension target
+#if defined(M13_APP_EXTENSIONS)
+    if ([UIScreen mainScreen].bounds.size.width < [UIScreen mainScreen].bounds.size.height) {
+        orientation = UIInterfaceOrientationPortrait;
+    } else {
+        orientation = UIInterfaceOrientationLandscapeLeft;
+    }
+#else
+    orientation = [UIApplication sharedApplication].statusBarOrientation;
+#endif
+  
+  return orientation;
+}
+
 #pragma mark Drawing
 
 - (void)showProgress
@@ -144,7 +164,7 @@ static char secondaryColorKey;
 
 - (void)updateProgress
 {
-    [self updateProgressWithInterfaceOrientation:[UIApplication sharedApplication].statusBarOrientation];
+    [self updateProgressWithInterfaceOrientation:[self currentDeviceOrientation]];
 }
 
 - (void)updateProgressWithInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
@@ -213,7 +233,7 @@ static char secondaryColorKey;
 
 - (void)drawIndeterminate
 {
-    [self drawIndeterminateWithInterfaceOrientation:[UIApplication sharedApplication].statusBarOrientation];
+    [self drawIndeterminateWithInterfaceOrientation:[self currentDeviceOrientation]];
 }
 
 - (void)drawIndeterminateWithInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation


### PR DESCRIPTION
Fix for issue #75
1- Use a preprocessor Macro "M13_APP_EXTENSIONS" for app extension target to avoid compile issues.
2- Avoid using [UIApplication sharedApplication].statusBarOrientation] for app extension - instead use simple method to get device orientation based on UIScreen bounds.