### PR TITLE
Fixed M13ProgressHUD not updating own progress value when setProgre…

### DIFF
--- a/Classes/HUD/M13ProgressHUD.m
+++ b/Classes/HUD/M13ProgressHUD.m
@@ -286,6 +286,7 @@
 - (void)setProgress:(CGFloat)progress animated:(BOOL)animated
 {
     [_progressView setProgress:progress animated:animated];
+	self.progress = progress;
 }
 
 - (void)performAction:(M13ProgressViewAction)action animated:(BOOL)animated


### PR DESCRIPTION
Previously, calling progressHUD.progress will always return 0 because progress was never updated in M13ProgressHUD when setProgress was called.

This allows you to step progress using M13ProgressHUD progress value like so:

`progressHUD?.setProgress(progressHUD!.progress+step, animated: false)`
